### PR TITLE
(maint) Update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -207,9 +207,6 @@ Style/SpaceInsideParens:
 Style/LeadingCommentSpace:
   Enabled: true
 
-Style/SingleSpaceBeforeFirstArg:
-  Enabled: true
-
 Style/SpaceAfterColon:
   Enabled: true
 
@@ -328,7 +325,10 @@ Style/TrailingWhitespace:
 Style/StringLiterals:
   Enabled: true
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: true
+
+Style/TrailingCommaInArguments:
   Enabled: true
 
 Style/GlobalVars:
@@ -475,7 +475,7 @@ Metrics/ParameterLists:
 Lint/RequireParentheses:
   Enabled: true
 
-Lint/SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: true
 
 Style/ModuleFunction:

--- a/lib/lock_manager/worker.rb
+++ b/lib/lock_manager/worker.rb
@@ -72,15 +72,13 @@ class LockManager
 
     def polling_lock(user, reason = nil)
       sleep_duration = 1
+      return lock(user, reason) unless locked?
       loop do
-        if locked?
-          log "#{host} is locked..."
-          log "waiting #{sleep_duration} seconds."
-          sleep sleep_duration
-          sleep_duration *= 2
-        else
-          break
-        end
+        log "#{host} is locked..."
+        log "waiting #{sleep_duration} seconds."
+        sleep sleep_duration
+        sleep_duration *= 2
+        break unless locked?
       end
       lock(user, reason)
     end


### PR DESCRIPTION
This commit updates rubocop to the latest version and updates the cops
that were giving warnings. Because of the new Guard Clause issue, a
small refactor was required for polling_lock as well.