### PR TITLE
Require only ruby version 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ notifications:
 rvm:
   - 2.2.0
   - 2.1.5
+  - 1.9.3
 services:
   - redis-server

--- a/lock_manager.gemspec
+++ b/lock_manager.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/lock_manager'
   gem.specification_version = 3
-  gem.required_ruby_version = '~> 2.1'
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_development_dependency('yard', '~> 0.8')
   gem.add_development_dependency('minitest')


### PR DESCRIPTION
The beaker test runner still supports 1.9.3 and needs all of its gems to
also support 1.9.3 as well.