### PR TITLE
(maint) Update rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,10 +213,10 @@ Style/SpaceAfterColon:
 Style/SpaceAfterComma:
   Enabled: true
 
-Style/SpaceAfterControlKeyword:
+Style/SpaceAfterMethodName:
   Enabled: true
 
-Style/SpaceAfterMethodName:
+Style/SpaceAroundKeyword:
   Enabled: true
 
 Style/SpaceAfterNot:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group(:development, :test) do
   gem 'yard', :require => false
-  gem 'rubocop'
+  # rubocop breaks stuff every single release, so pinning.
+  gem 'rubocop',  '0.39.0'
   gem 'json'
   gem 'redis'
   gem 'rake'

--- a/lib/lock_manager.rb
+++ b/lib/lock_manager.rb
@@ -30,7 +30,7 @@ class LockManager
   end
 
   def connection
-    fail ArgumentError, ':type option is required' unless options[:type]
+    raise ArgumentError, ':type option is required' unless options[:type]
     @connection ||= LockManager::Connection.connection_class(options[:type]).new(options)
   end
 end

--- a/lib/lock_manager/connection.rb
+++ b/lib/lock_manager/connection.rb
@@ -8,7 +8,7 @@ class LockManager
         require 'lock_manager/redis_connection'
         LockManager::RedisConnection
       else
-        fail ArgumentError, "Unknown connection type: #{type}"
+        raise ArgumentError, "Unknown connection type: #{type}"
       end
     end
 
@@ -17,15 +17,15 @@ class LockManager
     end
 
     def write(key, value)
-      fail "Not implemented: write(#{key}, #{value})"
+      raise "Not implemented: write(#{key}, #{value})"
     end
 
     def read(key)
-      fail "Not implemented: read(#{key})"
+      raise "Not implemented: read(#{key})"
     end
 
     def remove(key)
-      fail "Not implemented: remove(#{key})"
+      raise "Not implemented: remove(#{key})"
     end
   end
 end

--- a/lib/lock_manager/redis_connection.rb
+++ b/lib/lock_manager/redis_connection.rb
@@ -6,7 +6,7 @@ class LockManager
 
     def initialize(options = {})
       super
-      fail ArgumentError, ':server option is mandatory for redis connections' unless options[:server]
+      raise ArgumentError, ':server option is mandatory for redis connections' unless options[:server]
       @server = options[:server]
       @port = options[:port]
     end

--- a/lib/lock_manager/worker.rb
+++ b/lib/lock_manager/worker.rb
@@ -7,7 +7,7 @@ class LockManager
     def initialize(connection, host)
       @connection = connection
       if host =~ Regexp.union(Resolv::IPv4::Regex, Resolv::IPv6::Regex)
-        fail ArgumentError, 'Please use a DNS name rather than an IP address.'
+        raise ArgumentError, 'Please use a DNS name rather than an IP address.'
       else
         # Using the shortname of the host has the downside of being unable to
         # lock two hosts with the same shortname and different domains.


### PR DESCRIPTION
Since rubocop renames, breaks, removes, and adds new cops every release,
it's kind of a pain. This commit updates to the lateset, 0.39.0, and
pins to that in the Gemfile. It also silences new issues the rubocop
found that were just fine a few weeks ago. *shakes fist*

I've pinned because otherwise a random version of rubocop can get pulled
in on TravisCI and cause tests to fail (as that happened this evening).