### PR TITLE
(maint) Cap exponential backoff for polling locks

### DIFF
--- a/lib/lock_manager/worker.rb
+++ b/lib/lock_manager/worker.rb
@@ -70,7 +70,7 @@ class LockManager
       result['user']
     end
 
-    def polling_lock(user, reason = nil)
+    def polling_lock(user, reason = nil, max_sleep = 600)
       sleep_duration = 1
       return lock(user, reason) unless locked?
       loop do
@@ -78,6 +78,7 @@ class LockManager
         log "waiting #{sleep_duration} seconds."
         sleep sleep_duration
         sleep_duration *= 2
+        sleep_duration = max_sleep if sleep_duration > max_sleep
         break unless locked?
       end
       lock(user, reason)


### PR DESCRIPTION
Prior to this commit, the exponential backoff
used for polling locks in uncapped. In some
scenarios, this can lead to very long polling
intervals.

This commit adds a "max_sleep" with a default
to cap the polling interval at 10 minutes.