### PR TITLE
(CPR-397) explicitly pin to a working version of Rainbow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,22 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+ruby_version = Gem::Version.new("#{RUBY_VERSION}")
+minimum_ruby = Gem::Version.new('2.0.0')
 
 gemspec
 
 group(:development, :test) do
-  gem 'simplecov', :require => false
-  gem 'yard', '~> 0.8', :require => false
+  gem 'simplecov', require: false
+  gem 'yard', '~> 0.8', require: false
   # rubocop breaks stuff every single release, so pinning.
   gem 'rubocop', '0.39.0'
   # rubocop depends on rainbow, but rainbow 2.2.0 is a broken
   # release -- don't let rubocop install it.
   gem 'rainbow', '~> 2.1.0'
-  gem 'json'
-  gem 'redis'
-  gem 'rake'
+  # Pin JSON if Ruby isn't at least 2.0.0 -- JSON 2.0.0
+  # and up no longer build on Ruby 1.9.3 because 1.9.3
+  # is a fossil.
+  gem('json', '< 2.0.0') if ruby_version <= minimum_ruby
   gem 'minitest'
+  gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ group(:development, :test) do
   gem 'yard', '~> 0.8', :require => false
   # rubocop breaks stuff every single release, so pinning.
   gem 'rubocop', '0.39.0'
+  # rubocop depends on rainbow, but rainbow 2.2.0 is a broken
+  # release -- don't let rubocop install it.
+  gem 'rainbow', '~> 2.1.0'
   gem 'json'
   gem 'redis'
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+gemspec
+
 group(:development, :test) do
   gem 'simplecov', :require => false
-  gem 'yard', :require => false
+  gem 'yard', '~> 0.8', :require => false
   # rubocop breaks stuff every single release, so pinning.
-  gem 'rubocop',  '0.39.0'
+  gem 'rubocop', '0.39.0'
   gem 'json'
   gem 'redis'
   gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,30 @@
-require 'rake/testtask'
+require "bundler/setup"
+require "bundler/gem_tasks"
+require "rake/testtask"
+require "rubocop/rake_task"
 
-Rake::TestTask.new do |t|
-  t.libs.push 'test'
-  t.pattern = 'test/**/*.rb'
-  t.warning = true
-  t.verbose = true
+desc "Test lock_manager"
+namespace :test do
+  Rake::TestTask.new(:spec) do |test|
+    test.libs << "test"
+    test.pattern = "test/**/*_spec.rb"
+    test.verbose = true
+    test.warning = true
+  end
+
+  desc "Test lock_manager and calculate test coverage"
+  task :coverage do
+    ENV["COVERAGE"] = "true"
+    Rake::Task["test:spec"].invoke
+  end
 end
 
-task :default => [ :check, :test]
-
-desc "Execute Rubocop checks on the codebase"
-task :check do
-  sh 'rubocop'
+desc "Run RuboCop"
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.patterns = ["lib/**/*.rb"]
 end
+
+desc "Run all spec tests and linters"
+task check: %w(test:spec rubocop)
+
+task default: [ :check, :test]

--- a/lock_manager.gemspec
+++ b/lock_manager.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |gem|
   gem.specification_version = 3
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_development_dependency('yard', '~> 0.8')
-  gem.add_development_dependency('minitest')
   gem.add_runtime_dependency('redis', '>= 3.2')
   gem.require_path = 'lib'
 


### PR DESCRIPTION
`lock_manager` depends on `rubocop`, which in turn requires `rainbow`. The explicit dependency is versioned, but the transitive dependency is not. `rainbow` recently pushed a broken 2.2.0 release, which is impacting our ability to get work done because anything that tries to install `lock_manager` fails. This PR addresses that, as well as updates some of the bootstrapping around `Rakefile` to ease releasing new versions.