### PR TITLE
(MAINT) Simplify some Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,9 @@ namespace :test do
 end
 
 desc "Run RuboCop"
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ["lib/**/*.rb"]
-end
+RuboCop::RakeTask.new(:rubocop)
 
 desc "Run all spec tests and linters"
 task check: %w(test:spec rubocop)
 
-task default: [ :check, :test]
+task default: [:check]


### PR DESCRIPTION
The new default is `check`, not `test` -- there is no longer a
standalone `test` task.
The `rubocop` task has also been simplified, since we don't need to
pass it any arguments by default.