### PR TITLE
Enforce a range for Redis dependency

### DIFF
--- a/lock_manager.gemspec
+++ b/lock_manager.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.specification_version = 3
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_runtime_dependency('redis', '>= 3.2')
+  gem.add_runtime_dependency('redis', ['>= 3.2', '< 4.0'])
   gem.require_path = 'lib'
 
   gem.files = Dir['lib/**/*.rb', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")


### PR DESCRIPTION
[redis.rb 4.0.0](https://rubygems.org/gems/redis/versions/4.0.0) was released on 2017-08-25, and it has a hard requirement on Ruby 2.2.2 or newer. That breaks most of the Travis CI integration targets used by Vanagon, so we should get out ahead of that before actual production runs start crapping out.